### PR TITLE
fix: proposal of changes for TextField.tsx

### DIFF
--- a/packages/frontend/src/components/UI/TextField.tsx
+++ b/packages/frontend/src/components/UI/TextField.tsx
@@ -25,6 +25,7 @@ export interface TextFieldProps
    */
   multiline?: boolean;
   sx?: ThemeUIStyleObject;
+  value?: string;
 }
 
 export const TextField: ForwardRefExoticComponent<
@@ -58,7 +59,6 @@ TextFieldProps & RefAttributes<any>
         </Label.Root>
         <div
           sx={{
-            maxWidth: 430,
             width: '100%',
             height: multiline ? 174 : 50,
             bg: 'background',


### PR DESCRIPTION
- The value needs to be set as a string on the interface to avoid TS errors on forms.

- `maxWidth: 430` on the Div containing the input, creates many CSS problems that are hard to solve, please let us decide inside our component how wide we want the element to be.